### PR TITLE
added margin and padding to the main container

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,12 +53,12 @@ export default function RootLayout({
                     className="h-7 w-7"
                     priority
                   />
-                  
+
                 </Link>
                 <UserMenu />
               </div>
             </header>
-            <main className="flex-1">
+            <main className="flex-1 mt-8 px-2">
               {children}
             </main>
             <Footer />


### PR DESCRIPTION
## Details

Icon and header titles are over each other on smaller screen.

<img width="918" height="500" alt="Screenshot 2025-10-27 at 10 24 27 PM" src="https://github.com/user-attachments/assets/b6a0c94a-22a1-4a24-a67e-63b26bba8c87" />

Apply margin top and the `<main/>` container 


|Screen size|Before|After|
|-|-|-|
|Large|<img width="800" height="817" alt="Screenshot 2025-10-27 at 10 22 15 PM" src="https://github.com/user-attachments/assets/8a857e28-6d20-4bae-8d97-5bdc55782cf8" />|<img width="800" height="791" alt="Screenshot 2025-10-27 at 10 17 15 PM" src="https://github.com/user-attachments/assets/16015215-472c-4e7a-8a3a-c6b0db1ba4ed" />|
|Small|<img width="400" height="817" alt="Screenshot 2025-10-27 at 10 22 23 PM" src="https://github.com/user-attachments/assets/aab9b603-b36e-41e0-90e0-91a2f25da173" />|<img width="400" height="802" alt="Screenshot 2025-10-27 at 10 17 24 PM" src="https://github.com/user-attachments/assets/2a168f27-6412-42f3-a308-140afa313d8d" />|



